### PR TITLE
AWS-S3 setting

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,15 +3,18 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-    aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
-    region: 'ap-northeast-1'
-  }
-
-  config.fog_directory  = 'furima73a'
-  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/furima73a'
+  if Rails.env.development? || Rails.env.test?
+    config.storage = :file
+  else
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory  = 'furima73a'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/furima73a'
+  end
 end


### PR DESCRIPTION
## what
- 開発、テスト環境の際は、画像の保存先がpublic
- 本番環境の際は、S3のバケットへ保存

## why
- AWSのアクセスキー、シークレットキーは宮本しか使用できないため、開発テスト環境下ではアプリのpublic下に保存され、本番環境下ではS3のバケットに保存されるようにするため